### PR TITLE
Fix: Use local background image

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,7 +16,7 @@
  * ======================================================= */
 html {
     /* 1. Das Bild wird auf das oberste Element gelegt. */
-    background: url('https://images.hdqwalls.com/wallpapers/glass-light-abstract-background-blue-background-3d-4k-dn.jpg') no-repeat center center fixed;
+    background: url('glass-light-abstract-background-blue-background-3d-4000x2250-8736.jpg') no-repeat center center fixed;
     background-size: cover;
     min-height: 100%;
 }


### PR DESCRIPTION
The background image was not being displayed because the CSS was referencing a broken external URL.

This change updates the `style.css` file to use the local background image file `glass-light-abstract-background-blue-background-3d-4000x2250-8736.jpg` instead of the remote URL.