### PR TITLE
Fix: Use local background image for the background

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@
 
 html {
     height: 100%;
-    background: url('https://images.hdqwalls.com/wallpapers/glass-light-abstract-background-blue-background-3d-4k-dn.jpg') no-repeat center center fixed;
+    background: url('glass-light-abstract-background-blue-background-3d-4000x2250-8736.jpg') no-repeat center center fixed;
     background-size: cover;
 }
 


### PR DESCRIPTION
The remote URL for the background image was not working, likely due to hotlinking prevention. This resulted in the background image not being displayed.

This change updates the `style.css` file to use the local background image file `glass-light-abstract-background-blue-background-3d-4000x2250-8736.jpg` which is present in the repository.